### PR TITLE
Fixed issue where parsing Map<T, U> type was throwing exception

### DIFF
--- a/codegen/src/main/kotlin/apifi/helpers/Functions.kt
+++ b/codegen/src/main/kotlin/apifi/helpers/Functions.kt
@@ -24,7 +24,7 @@ fun String.toKotlinPoetType(packageNameMapping: Map<String, String>): TypeName {
         val parts = this.split('<')
         val primaryType = parts[0]
         val parameters = parts[1].dropLast(1).split(",")
-        withPackage(primaryType).parameterizedBy(parameters.map { withPackage(it) })
+        withPackage(primaryType).parameterizedBy(parameters.map { withPackage(it.trim()) })
     } else {
         withPackage(this)
     }

--- a/codegen/src/test-res/codegen/all-paths.yml
+++ b/codegen/src/test-res/codegen/all-paths.yml
@@ -110,6 +110,11 @@ components:
             properties:
               name:
                 type: string
+              mapping:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
     Error:
       type: object
       required:

--- a/codegen/src/test-res/codegen/expected-models
+++ b/codegen/src/test-res/codegen/expected-models
@@ -4,6 +4,7 @@ import kotlin.Array
 import kotlin.Int
 import kotlin.Long
 import kotlin.String
+import kotlin.collections.Map
 
 data class Pet(
   val id: Long,
@@ -13,7 +14,8 @@ data class Pet(
 )
 
 data class Children(
-  val name: String?
+  val name: String?,
+  val mapping: Map<String, Int>?
 )
 
 data class Error(


### PR DESCRIPTION
Modelling of "Map<T,U>" type involves modelling T & U individually. Since T & U are extracted by splitting string by "," separator, extra spaces are added. We need to trim the extracted string parts.