### PR TITLE
codegen: Generate proper variable names for path/query params with hyphenated names

### DIFF
--- a/codegen/src/main/kotlin/apifi/codegen/ApiBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/ApiBuilder.kt
@@ -7,7 +7,7 @@ import com.squareup.kotlinpoet.*
 class ApiBuilder(private val apiMethodBuilder: ApiMethodBuilder = ApiMethodBuilder()) {
 
     fun build(name: String, paths: List<Path>, basePackageName: String, modelMapping: Map<String, String>): FileSpec {
-        val baseName = toTitleCase(name)
+        val baseName = name.toTitleCase()
         val controllerClassName = "${baseName}Api"
 
         val controllerInterfaceClass = ControllerInterfaceBuilder.build(paths, baseName)

--- a/codegen/src/main/kotlin/apifi/codegen/ApiMethodBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/ApiMethodBuilder.kt
@@ -11,7 +11,7 @@ class ApiMethodBuilder {
 
     fun methodFor(url: String, operation: Operation, modelMapping: Map<String, String>): FunSpec {
 
-        val httpMethodAnnotation = AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, toTitleCase(operation.type.toString())))
+        val httpMethodAnnotation = AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, operation.type.toString().toLowerCase().toTitleCase()))
                                                                .addMember("value = %S", url)
                                                                .build()
 
@@ -24,7 +24,7 @@ class ApiMethodBuilder {
 
 
         return FunSpec.builder(operation.name)
-                .also { b -> operation.responses?.let { b.addAnnotations(ExceptionAnnotationBuilder().exceptionAnnotationsFor(it)) } }
+                .also { b -> operation.responses.let { b.addAnnotations(ExceptionAnnotationBuilder().exceptionAnnotationsFor(it)) } }
                 .addAnnotation(httpMethodAnnotation)
                 .also { b -> contentTypeAnnotation?.let { b.addAnnotation(it) } }
                 .addParameters(operation.queryParamSpecs() + operation.pathParamSpecs() + operation.headerParamSpecs() + operation.requestParams(modelMapping))

--- a/codegen/src/main/kotlin/apifi/codegen/ApiMethodBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/ApiMethodBuilder.kt
@@ -19,7 +19,7 @@ class ApiMethodBuilder {
                                                                 .also { ab -> it.forEach { ab.addMember("%S", it) } }
                                                                 .build()}
 
-        val returnStatement =  "HttpResponse.ok(controller.${operation.name}(${(operation.queryParamSpecNames() + operation.pathParamSpecNames() + operation.requestParamNames(modelMapping)).joinToString()}))"
+        val returnStatement =  "HttpResponse.ok(controller.${operation.name}(${(operation.queryParamSpecNames(modelMapping) + operation.pathParamSpecNames(modelMapping) + operation.requestParamNames(modelMapping)).joinToString()}))"
 
 
 
@@ -27,7 +27,7 @@ class ApiMethodBuilder {
                 .also { b -> operation.responses.let { b.addAnnotations(ExceptionAnnotationBuilder().exceptionAnnotationsFor(it)) } }
                 .addAnnotation(httpMethodAnnotation)
                 .also { b -> contentTypeAnnotation?.let { b.addAnnotation(it) } }
-                .addParameters(operation.queryParamSpecs() + operation.pathParamSpecs() + operation.headerParamSpecs() + operation.requestParams(modelMapping))
+                .addParameters(operation.queryParamSpecs(modelMapping) + operation.pathParamSpecs(modelMapping) + operation.headerParamSpecs() + operation.requestParams(modelMapping))
                 .also { operation.returnType(modelMapping)?.let { rt -> it.returns(rt) } }
                 .addStatement("return $returnStatement")
                 .build()

--- a/codegen/src/main/kotlin/apifi/codegen/ControllerInterfaceBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/ControllerInterfaceBuilder.kt
@@ -1,5 +1,6 @@
 package apifi.codegen
 
+import apifi.helpers.toCamelCase
 import apifi.helpers.toKotlinPoetType
 import apifi.parser.models.Path
 import com.squareup.kotlinpoet.*
@@ -11,7 +12,7 @@ object ControllerInterfaceBuilder {
                 val queryParams = operation.queryParams()
                 val pathParams = operation.pathParams()
                 val params = (queryParams + pathParams).map {
-                    ParameterSpec.builder(it.name, it.dataType.toKotlinPoetType().copy(nullable = !it.isRequired)).build()
+                    ParameterSpec.builder(it.name.toCamelCase(), it.dataType.toKotlinPoetType().copy(nullable = !it.isRequired)).build()
                 }
 
                 val requestBodyParam = operation.request?.let {
@@ -24,7 +25,7 @@ object ControllerInterfaceBuilder {
                         .addModifiers(KModifier.ABSTRACT)
                         .addParameters(params)
                         .also { requestBodyParam?.let { req -> it.addParameter(req) } }
-                        .also { (operation.responses?.firstOrNull()?.let { res -> it.returns(res.type.toKotlinPoetType()) }) }
+                        .also { (operation.responses.firstOrNull()?.let { res -> it.returns(res.type.toKotlinPoetType()) }) }
                         .build()
             } ?: emptyList()
         }

--- a/codegen/src/main/kotlin/apifi/codegen/HeaderBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/HeaderBuilder.kt
@@ -9,10 +9,10 @@ import com.squareup.kotlinpoet.ParameterSpec
 
 object HeaderBuilder {
     fun build(pathParam: Param): ParameterSpec =
-            ParameterSpec.builder(toCamelCase(pathParam.name), pathParam.dataType.toKotlinPoetType().copy(nullable = !pathParam.isRequired))
-                    .addAnnotation(
-                            AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "Header"))
-                                    .addMember("value = %S", pathParam.name)
-                                    .build())
-                    .build()
+        ParameterSpec.builder(pathParam.name.toCamelCase(), pathParam.dataType.toKotlinPoetType().copy(nullable = !pathParam.isRequired))
+            .addAnnotation(
+                AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "Header"))
+                    .addMember("value = %S", pathParam.name)
+                    .build())
+            .build()
 }

--- a/codegen/src/main/kotlin/apifi/codegen/HeaderBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/HeaderBuilder.kt
@@ -1,8 +1,8 @@
 package apifi.codegen
 
-import apifi.parser.models.Param
 import apifi.helpers.toCamelCase
 import apifi.helpers.toKotlinPoetType
+import apifi.parser.models.Param
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterSpec

--- a/codegen/src/main/kotlin/apifi/codegen/OperationExtension.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/OperationExtension.kt
@@ -10,15 +10,15 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 
 
-fun Operation.queryParamSpecs() = params.filter { it.type == ParamType.Query }.map(QueryParamBuilder::build)
+fun Operation.queryParamSpecs(modelMapping: Map<String, String>) = queryParams().map { QueryParamBuilder.build(it, modelMapping) }
 
-fun Operation.queryParamSpecNames() = params.filter { it.type == ParamType.Query }.map(QueryParamBuilder::build).map { it.name }
+fun Operation.queryParamSpecNames(modelMapping: Map<String, String>) = queryParamSpecs(modelMapping).map { it.name }
 
 fun Operation.queryParams(): List<Param> = params.filter { it.type == ParamType.Query }
 
-fun Operation.pathParamSpecs() = params.filter { it.type == ParamType.Path }.map(PathVariableBuilder::build)
+fun Operation.pathParamSpecs(modelMapping: Map<String, String>) = pathParams().map { PathVariableBuilder.build(it, modelMapping) }
 
-fun Operation.pathParamSpecNames() = params.filter { it.type == ParamType.Path }.map(PathVariableBuilder::build).map { it.name }
+fun Operation.pathParamSpecNames(modelMapping: Map<String, String>) = pathParamSpecs(modelMapping).map { it.name }
 
 fun Operation.pathParams(): List<Param> = params.filter { it.type == ParamType.Path }
 
@@ -26,14 +26,14 @@ fun Operation.headerParamSpecs() = params.filter { it.type == ParamType.Header }
 
 fun Operation.requestParams(modelMapping: Map<String, String>) = request?.let {
     listOf(ParameterSpec.builder("body", it.type.toKotlinPoetType(modelMapping))
-            .addAnnotation(ClassName(micronautHttpAnnotationPackage, "Body"))
-            .build())
+        .addAnnotation(ClassName(micronautHttpAnnotationPackage, "Body"))
+        .build())
 } ?: emptyList()
 
 fun Operation.requestParamNames(modelMapping: Map<String, String>) = request?.let {
     listOf(ParameterSpec.builder("body", it.type.toKotlinPoetType(modelMapping))
-            .addAnnotation(ClassName(micronautHttpAnnotationPackage, "Body"))
-            .build())
+        .addAnnotation(ClassName(micronautHttpAnnotationPackage, "Body"))
+        .build())
 }?.map { it.name } ?: emptyList()
 
 fun Operation.returnType(modelMapping: Map<String, String>): ParameterizedTypeName? =

--- a/codegen/src/main/kotlin/apifi/codegen/PathVariableBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/PathVariableBuilder.kt
@@ -2,15 +2,14 @@ package apifi.codegen
 
 import apifi.helpers.toCamelCase
 import apifi.helpers.toKotlinPoetType
-import apifi.helpers.toTitleCase
 import apifi.parser.models.Param
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterSpec
 
 object PathVariableBuilder {
-    fun build(pathParam: Param): ParameterSpec =
-        ParameterSpec.builder(pathParam.name.toCamelCase(), pathParam.dataType.toKotlinPoetType().copy(nullable = !pathParam.isRequired))
+    fun build(pathParam: Param, modelMapping: Map<String, String>): ParameterSpec =
+        ParameterSpec.builder(pathParam.name.toCamelCase(), pathParam.dataType.toKotlinPoetType(modelMapping).copy(nullable = !pathParam.isRequired))
             .addAnnotation(AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "PathVariable"))
                 .also { if (pathParam.name != pathParam.name.toCamelCase()) it.addMember("value = %S", pathParam.name) }
                 .build())

--- a/codegen/src/main/kotlin/apifi/codegen/PathVariableBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/PathVariableBuilder.kt
@@ -1,13 +1,18 @@
 package apifi.codegen
 
+import apifi.helpers.toCamelCase
 import apifi.helpers.toKotlinPoetType
+import apifi.helpers.toTitleCase
 import apifi.parser.models.Param
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterSpec
 
 object PathVariableBuilder {
-  fun build(pathParam: Param): ParameterSpec =
-      ParameterSpec.builder(pathParam.name, pathParam.dataType.toKotlinPoetType().copy(nullable = !pathParam.isRequired))
-          .addAnnotation(ClassName(micronautHttpAnnotationPackage, "PathVariable"))
-          .build()
+    fun build(pathParam: Param): ParameterSpec =
+        ParameterSpec.builder(pathParam.name.toCamelCase(), pathParam.dataType.toKotlinPoetType().copy(nullable = !pathParam.isRequired))
+            .addAnnotation(AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "PathVariable"))
+                .also { if (pathParam.name != pathParam.name.toCamelCase()) it.addMember("value = %S", pathParam.name) }
+                .build())
+            .build()
 }

--- a/codegen/src/main/kotlin/apifi/codegen/QueryParamBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/QueryParamBuilder.kt
@@ -8,8 +8,8 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterSpec
 
 object QueryParamBuilder {
-    fun build(queryParam: Param): ParameterSpec =
-        ParameterSpec.builder(queryParam.name.toCamelCase(), queryParam.dataType.toKotlinPoetType().copy(nullable = !queryParam.isRequired))
+    fun build(queryParam: Param, modelMapping: Map<String, String>): ParameterSpec =
+        ParameterSpec.builder(queryParam.name.toCamelCase(), queryParam.dataType.toKotlinPoetType(modelMapping).copy(nullable = !queryParam.isRequired))
             .addAnnotation(AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "QueryValue"))
                 .also { if (queryParam.name != queryParam.name.toCamelCase()) it.addMember("value = %S", queryParam.name) }
                 .build())

--- a/codegen/src/main/kotlin/apifi/codegen/QueryParamBuilder.kt
+++ b/codegen/src/main/kotlin/apifi/codegen/QueryParamBuilder.kt
@@ -1,13 +1,17 @@
 package apifi.codegen
 
+import apifi.helpers.toCamelCase
 import apifi.helpers.toKotlinPoetType
 import apifi.parser.models.Param
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterSpec
 
 object QueryParamBuilder {
     fun build(queryParam: Param): ParameterSpec =
-            ParameterSpec.builder(queryParam.name, queryParam.dataType.toKotlinPoetType().copy(nullable = !queryParam.isRequired))
-                    .addAnnotation(ClassName(micronautHttpAnnotationPackage, "QueryValue"))
-                    .build()
+        ParameterSpec.builder(queryParam.name.toCamelCase(), queryParam.dataType.toKotlinPoetType().copy(nullable = !queryParam.isRequired))
+            .addAnnotation(AnnotationSpec.builder(ClassName(micronautHttpAnnotationPackage, "QueryValue"))
+                .also { if (queryParam.name != queryParam.name.toCamelCase()) it.addMember("value = %S", queryParam.name) }
+                .build())
+            .build()
 }

--- a/codegen/src/main/kotlin/apifi/helpers/Functions.kt
+++ b/codegen/src/main/kotlin/apifi/helpers/Functions.kt
@@ -9,9 +9,9 @@ import org.apache.commons.text.CaseUtils
 import org.openapitools.codegen.CodegenModel
 import org.openapitools.codegen.languages.KotlinClientCodegen
 
-fun toTitleCase(s: String): String = CaseUtils.toCamelCase(s, true, '_', '-', '/')
-
-fun toCamelCase(s: String): String = CaseUtils.toCamelCase(s, false, '_', '-', ' ', '/')
+private fun toCamelCase(s: String, capitalizeFirstLetter: Boolean) = if (listOf('_', '-', '/', ' ').any { s.contains(it) }) CaseUtils.toCamelCase(s, capitalizeFirstLetter, '_', '-', '/', ' ') else s
+fun String.toTitleCase(): String = toCamelCase(this.capitalize(), true)
+fun String.toCamelCase(): String = toCamelCase(this, false)
 
 fun <T> Schema<T>.toCodeGenModel(name: String): CodegenModel = KotlinClientCodegen().fromModel(name, this)
 fun <T> Schema<T>.toCodeGenModel(): CodegenModel = this.toCodeGenModel("any")

--- a/codegen/src/main/kotlin/apifi/parser/ModelParser.kt
+++ b/codegen/src/main/kotlin/apifi/parser/ModelParser.kt
@@ -17,7 +17,7 @@ object ModelParser {
             return modelsFromSchema(name, (schema as ArraySchema).items)
         }
         val codeGenModel = schema.toCodeGenModel(name)
-        val propertyModels = schema.properties?.filter { shouldCreateModel(it.value) }?.flatMap { modelsFromSchema(toTitleCase(it.key), it.value) }
+        val propertyModels = schema.properties?.filter { shouldCreateModel(it.value) }?.flatMap { modelsFromSchema(it.key.toTitleCase(), it.value) }
             ?: emptyList()
 
         val primaryModel = Model(
@@ -34,7 +34,7 @@ object ModelParser {
         property is ObjectSchema || (property is ArraySchema && property.items is ObjectSchema) || property.isEnum()
 
     private fun dataType(property: CodegenProperty, models: List<Model>) =
-        models.firstOrNull { m -> m.name == toTitleCase(property.name) }?.name?.let {
+        models.firstOrNull { m -> m.name == property.name.toTitleCase() }?.name?.let {
             if (property.isListContainer) "kotlin.Array<$it>" else it
         } ?: property.dataType
 

--- a/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
+++ b/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
@@ -21,14 +21,14 @@ object PathsParser {
                 val responses = ResponseBodyParser.parse(operation.responses, operationSpecifier)
                 models.addAll(request?.models ?: emptyList())
                 models.addAll(responses?.models ?: emptyList())
-                Operation(httpMethod, operation.operationId ?: toCamelCase(httpMethod.toString()),
-                        operation.tags ?: emptyList(), params, request?.result, responses?.result ?: emptyList())
+                Operation(httpMethod, operation.operationId ?: httpMethod.toString().toLowerCase(),
+                    operation.tags ?: emptyList(), params, request?.result, responses?.result ?: emptyList())
             }
             Path(endpoint, operations)
         } ?: emptyList(), models)
     }
 
     private fun operationSpecifier(operation: io.swagger.v3.oas.models.Operation, httpMethod: PathItem.HttpMethod, endpoint: String) =
-            (operation.operationId
-                    ?: toTitleCase(httpMethod.toString() + endpoint.replace(Regex("[^A-Za-z ]"), " ")))
+        (operation.operationId
+            ?: (httpMethod.toString() + endpoint.replace(Regex("[^A-Za-z ]"), " ")).toTitleCase())
 }

--- a/codegen/src/test/kotlin/apifi/codegen/ControllerInterfaceBuilderTest.kt
+++ b/codegen/src/test/kotlin/apifi/codegen/ControllerInterfaceBuilderTest.kt
@@ -24,7 +24,7 @@ class ControllerInterfaceBuilderTest : DescribeSpec({
 
         it("should generate controller interface methods with methods including params") {
             val queryParam = Param("limit", "kotlin.Int", true, ParamType.Query)
-            val pathParam = Param("petId", "kotlin.Int", true, ParamType.Path)
+            val pathParam = Param("pet-id", "kotlin.Int", true, ParamType.Path)
             val headerParam = Param("x-header", "kotlin.String", true, ParamType.Header)
 
             val path = Path("/pets", listOf(

--- a/codegen/src/test/kotlin/apifi/codegen/PathVariableBuilderTest.kt
+++ b/codegen/src/test/kotlin/apifi/codegen/PathVariableBuilderTest.kt
@@ -12,6 +12,11 @@ class PathVariableBuilderTest : DescribeSpec({
             PathVariableBuilder.build(pathParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String"
         }
 
+        it("should return correct ParameterSpec for hyphenated path param") {
+            val pathParam = Param("param-name", "String", true, ParamType.Path)
+            PathVariableBuilder.build(pathParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable(value = \"param-name\") paramName: String"
+        }
+
         it("should return correct ParameterSpec for optional path param") {
             val queryParam = Param("name", "String", false, ParamType.Path)
             PathVariableBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String?"

--- a/codegen/src/test/kotlin/apifi/codegen/PathVariableBuilderTest.kt
+++ b/codegen/src/test/kotlin/apifi/codegen/PathVariableBuilderTest.kt
@@ -9,17 +9,22 @@ class PathVariableBuilderTest : DescribeSpec({
     describe("PathVariableBuilder") {
         it("should return correct ParameterSpec for mandatory path param") {
             val pathParam = Param("name", "String", true, ParamType.Path)
-            PathVariableBuilder.build(pathParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String"
+            PathVariableBuilder.build(pathParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String"
         }
 
         it("should return correct ParameterSpec for hyphenated path param") {
             val pathParam = Param("param-name", "String", true, ParamType.Path)
-            PathVariableBuilder.build(pathParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable(value = \"param-name\") paramName: String"
+            PathVariableBuilder.build(pathParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable(value = \"param-name\") paramName: String"
+        }
+
+        it("should return correct ParameterSpec for path param with custom model") {
+            val pathParam = Param("pet", "Pet", true, ParamType.Path)
+            PathVariableBuilder.build(pathParam, mapOf("Pet" to "com.api.Pet")).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable pet: com.api.Pet"
         }
 
         it("should return correct ParameterSpec for optional path param") {
-            val queryParam = Param("name", "String", false, ParamType.Path)
-            PathVariableBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String?"
+            val pathParam = Param("name", "String", false, ParamType.Path)
+            PathVariableBuilder.build(pathParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.PathVariable name: String?"
         }
     }
 })

--- a/codegen/src/test/kotlin/apifi/codegen/QueryParamBuilderTest.kt
+++ b/codegen/src/test/kotlin/apifi/codegen/QueryParamBuilderTest.kt
@@ -9,17 +9,22 @@ class QueryParamBuilderTest : DescribeSpec({
     describe("QueryParamBuilder") {
         it("should return correct ParameterSpec for mandatory query param") {
             val queryParam = Param("name", "String", true, ParamType.Query)
-            QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String"
+            QueryParamBuilder.build(queryParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String"
         }
 
         it("should return correct ParameterSpec for hyphenated query param") {
             val queryParam = Param("query-name", "String", true, ParamType.Query)
-            QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue(value = \"query-name\") queryName: String"
+            QueryParamBuilder.build(queryParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue(value = \"query-name\") queryName: String"
+        }
+
+        it("should return correct ParameterSpec for query param with custom model") {
+            val queryParam = Param("pet", "Pet", true, ParamType.Query)
+            QueryParamBuilder.build(queryParam, mapOf("Pet" to "com.api.Pet")).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue pet: com.api.Pet"
         }
 
         it("should return correct ParameterSpec for optional query param") {
             val queryParam = Param("name", "String", false, ParamType.Query)
-            QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String?"
+            QueryParamBuilder.build(queryParam, emptyMap()).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String?"
         }
     }
 

--- a/codegen/src/test/kotlin/apifi/codegen/QueryParamBuilderTest.kt
+++ b/codegen/src/test/kotlin/apifi/codegen/QueryParamBuilderTest.kt
@@ -12,6 +12,11 @@ class QueryParamBuilderTest : DescribeSpec({
             QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String"
         }
 
+        it("should return correct ParameterSpec for hyphenated query param") {
+            val queryParam = Param("query-name", "String", true, ParamType.Query)
+            QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue(value = \"query-name\") queryName: String"
+        }
+
         it("should return correct ParameterSpec for optional query param") {
             val queryParam = Param("name", "String", false, ParamType.Query)
             QueryParamBuilder.build(queryParam).toString().trimIndent() shouldBe "@io.micronaut.http.annotation.QueryValue name: String?"


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [x] Refactoring
-   [ ] Other... Please describe:

### What is the current behavior?

The path/query params or headers can have hyphen (or underscore) in the api spec. Right now, the function parameter names of these are generated with hyphen which is incorrect for languages like kotlin.

## Fixes #39 

### What is the new behavior?

These param names will be converted to camel case.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.