### PR TITLE
codegen: applying kotlin naming rules to operationId param

### DIFF
--- a/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
+++ b/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
@@ -1,6 +1,7 @@
 package apifi.parser
 
 import apifi.helpers.replaceArrayToList
+import apifi.helpers.toCamelCase
 import apifi.helpers.toTitleCase
 import apifi.helpers.typeDeclaration
 import apifi.models.Model
@@ -21,7 +22,7 @@ object PathsParser {
                 val responses = ResponseBodyParser.parse(operation.responses, operationSpecifier)
                 models.addAll(request?.models ?: emptyList())
                 models.addAll(responses?.models ?: emptyList())
-                Operation(httpMethod, operation.operationId ?: httpMethod.toString().toLowerCase(),
+                Operation(httpMethod, getValidOperationId(operation.operationId) ?: httpMethod.toString().toLowerCase(),
                     operation.tags ?: emptyList(), params, request?.result, responses?.result ?: emptyList())
             }
             Path(endpoint, operations)
@@ -31,4 +32,17 @@ object PathsParser {
     private fun operationSpecifier(operation: io.swagger.v3.oas.models.Operation, httpMethod: PathItem.HttpMethod, endpoint: String) =
         (operation.operationId
             ?: (httpMethod.toString() + endpoint.replace(Regex("[^A-Za-z ]"), " ")).toTitleCase())
+
+    /**
+     * Must start with a lower case letter and use the camel case and no underscores.
+     */
+    private fun getValidOperationId(operationId: String?): String? {
+        return operationId?.let {
+            if (it.first().isDigit()) {
+                operationId.substring(1).toCamelCase()
+            } else {
+                operationId.toCamelCase()
+            }
+        }
+    }
 }

--- a/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
+++ b/codegen/src/main/kotlin/apifi/parser/PathsParser.kt
@@ -39,7 +39,7 @@ object PathsParser {
     private fun getValidOperationId(operationId: String?): String? {
         return operationId?.let {
             if (it.first().isDigit()) {
-                operationId.substring(1).toCamelCase()
+                "operation$operationId".toCamelCase()
             } else {
                 operationId.toCamelCase()
             }

--- a/codegen/src/test-res/parser/params/with-invalid-operationId.yml
+++ b/codegen/src/test-res/parser/params/with-invalid-operationId.yml
@@ -1,0 +1,16 @@
+openapi: "3.0.0"
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: '1 list All_Pets '
+      parameters:
+        - name: id
+          in: query
+          description: id to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string

--- a/codegen/src/test/kotlin/apifi/parser/PathsParserTest.kt
+++ b/codegen/src/test/kotlin/apifi/parser/PathsParserTest.kt
@@ -64,7 +64,7 @@ class PathsParserTest : DescribeSpec({
             val path = PathsParser.parse(openApi.paths).result[0]
             val operation = path.operations?.first()
             operation shouldNotBe null
-            operation?.name shouldBe "listAllPets"
+            operation?.name shouldBe "operation1ListAllPets"
         }
     }
 })

--- a/codegen/src/test/kotlin/apifi/parser/PathsParserTest.kt
+++ b/codegen/src/test/kotlin/apifi/parser/PathsParserTest.kt
@@ -5,6 +5,7 @@ import apifi.parser.models.Param
 import apifi.parser.models.ParamType
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.parser.OpenAPIV3Parser
 import org.apache.commons.io.FileUtils
@@ -56,6 +57,14 @@ class PathsParserTest : DescribeSpec({
             path.url shouldBe "/pets"
             path.operations!![0].type shouldBe HttpMethod.GET
             path.operations!![0].params[0] shouldBe Param("id", "kotlin.collections.List<kotlin.String>", false, ParamType.Query)
+        }
+        it("with invalid operationId") {
+            val file = FileUtils.getFile("src", "test-res", "parser", "params", "with-invalid-operationId.yml").readText().trimIndent()
+            val openApi = OpenAPIV3Parser().readContents(file).openAPI
+            val path = PathsParser.parse(openApi.paths).result[0]
+            val operation = path.operations?.first()
+            operation shouldNotBe null
+            operation?.name shouldBe "listAllPets"
         }
     }
 })


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring
-   [ ] Other... Please describe:

### What is the current behavior?
Currently if `operationId` contains whitespaces the resulting function name is wrongly createad as `foo bar()`. This hould be prevented.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes #30 

### What is the new behavior?
From now on the `operationId` will follow naming rules specified for kotlin [functions](https://kotlinlang.org/docs/reference/coding-conventions.html#function-names). That means that the first character is removed in case it is a digit. After this check the `Functions.toCamelCase()` function is applied.
### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

- none